### PR TITLE
Allow eslint to check JSX syntax, if used, too

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -79,5 +79,6 @@ ecmaFeatures:
   defaultParams: true
   destructuring: true
   forOf: true
+  jsx: true
   spread: true
   templateStrings: true


### PR DESCRIPTION
We're using a lot of JSX in a lot of projects, so making sure eslint catches JSX syntax errors, too, instead of dying on `<`, probably makes a lot of sense